### PR TITLE
remove check for file system

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,11 +115,12 @@ const openArchive = function (file, noCache) {
 // ensure non-breaking changes
 exports.get = (file, archive) => {
   log.debug('get() : ' + file + ', ' + archive);
-  if (['darwin', 'linux'].indexOf(process.platform) > -1) {
-    return exports.extractFile(file, archive)
-  } else {
-    return exports.extractFileJS(file, archive)
-  }
+  return exports.extractFileJS(file, archive);
+  // if (['darwin', 'linux'].indexOf(process.platform) > -1) {
+  //   return exports.extractFile(file, archive)
+  // } else {
+  //   return exports.extractFileJS(file, archive)
+  // }
 }
 
 // returns the content of a file in a replay archive


### PR DESCRIPTION
this removes the check for OS and defaults all file system to using the extractViaJs method;
Have found this allows my linux and mac system to parse correctly.